### PR TITLE
Simplify test S3 file retrieval

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ memmap = { version = "0.7", optional = true }
 twoway = "0.2"
 
 [dev-dependencies]
-rust-s3 = "0.26"
+attohttpc = "0.16"
 criterion = "0.3"
 
 [[bench]]

--- a/tests/utils.rs
+++ b/tests/utils.rs
@@ -1,4 +1,3 @@
-use s3::{bucket::Bucket, creds::Credentials, region::Region};
 use std::fs;
 use std::path::Path;
 
@@ -17,22 +16,15 @@ pub fn request<S: AsRef<str>>(input: S) -> Vec<u8> {
         fs::read(cache).unwrap()
     } else {
         println!("cache miss: {}", reffed);
-        let bucket_name = "ck3saves-test-cases";
-        let region_name = "us-west-002".to_string();
-        let endpoint = "s3.us-west-002.backblazeb2.com".to_string();
-        let region = Region::Custom {
-            region: region_name,
-            endpoint,
-        };
-        let credentials = Credentials::anonymous().unwrap();
-        let bucket = Bucket::new(bucket_name, region, credentials).unwrap();
-        let (data, code) = bucket.get_object_blocking(reffed).unwrap();
+        let url = format!("https://ck3saves-test-cases.s3.us-west-002.backblazeb2.com/{}", reffed);
+        let resp = attohttpc::get(&url).send().unwrap();
 
-        if code != 200 {
+        if !resp.is_success() {
             panic!("expected a 200 code from s3");
         } else {
-            fs::create_dir_all(cache.parent().unwrap()).unwrap();
-            fs::write(cache, &data).unwrap();
+            let data = resp.bytes().unwrap();
+            std::fs::create_dir_all(cache.parent().unwrap()).unwrap();
+            std::fs::write(&cache, &data).unwrap();
             data
         }
     }


### PR DESCRIPTION
No need to use a complicated stack when a simple HTTP client will
suffice