### PR TITLE
Support an unbounded zip header

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ jomini = "0.11"
 zip = { version =  "0.5", default-features = false, features = ["deflate"] }
 serde = { version = "1", features = ["derive"] }
 memmap = { version = "0.7", optional = true }
-twoway = "0.2"
 
 [dev-dependencies]
 attohttpc = "0.16"

--- a/tests/ironman.rs
+++ b/tests/ironman.rs
@@ -55,6 +55,10 @@ fn test_ck3_binary_autosave() -> Result<(), Box<dyn std::error::Error>> {
     let (save, encoding) = Ck3Extractor::extract_save(reader)?;
     assert_eq!(encoding, Encoding::Binary);
     assert_eq!(save.meta_data.version, String::from("1.0.2"));
+
+    let (save, encoding) = Ck3Extractor::extract_header(&buffer[..])?;
+    assert_eq!(encoding, Encoding::Binary);
+    assert_eq!(save.meta_data.version, String::from("1.0.2"));
     Ok(())
 }
 


### PR DESCRIPTION
Previously we'd search the first 64kb for the zip in order to determine
how to decode the file, but it turns out that zips orient themselves by
the end of the file so we can take advantage that any zip parser worth
its salt will ignore (and indeed, expose) the number of bytes in the
header.

Doing this allowed the code to be shorter without a performance hit.
Additionally an unknown bug was solved with this method. And there is
one less dependency (not that `twoway` was very big to begin with)